### PR TITLE
Write PID to file in POSIX systems

### DIFF
--- a/_example.go
+++ b/_example.go
@@ -1,19 +1,18 @@
 package main
 
 import (
-    "fmt"
-    "time"
+	"fmt"
+	"time"
 )
 
 func main() {
 
-    _, err := CreateLockFile("plop.lock")
-    if err != nil {
-        fmt.Println("an instance already exists")
-        return
-    }
+	_, err := CreateLockFile("plop.lock")
+	if err != nil {
+		fmt.Println("an instance already exists")
+		return
+	}
 
-    time.Sleep(10 * time.Second)
-    fmt.Println("end")
+	time.Sleep(10 * time.Second)
+	fmt.Println("end")
 }
-

--- a/lock_posix.go
+++ b/lock_posix.go
@@ -3,34 +3,52 @@
 package singleinstance
 
 import (
-    "os"
-    "syscall"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"syscall"
 )
 
 // CreateLockFile try to create a file with given name
 // and acquire an exclusive lock on it
 // if the file already exists AND is still locked, it will fail
 func CreateLockFile(filename string) (*os.File, error) {
+	var (
+		file *os.File
+		err  error
+	)
 
-    var (
-        file *os.File
-        err  error
-    )
+	if _, err = os.Stat(filename); os.IsNotExist(err) {
+		// file doesnt exist, create
+		file, err = os.Create(filename)
+	} else {
+		// file does exist, open
+		file, err = os.OpenFile(filename, os.O_WRONLY, 0666)
+	}
 
-    if _, err = os.Stat(filename); os.IsNotExist(err) {
-        // file doesnt exist, create
-        file, err = os.Create(filename)
-    } else {
-        // file does exist, open
-        file, err = os.OpenFile(filename, os.O_WRONLY, 0666)
-    }
+	if err != nil {
+		return nil, err
+	}
 
-    if err != nil {
-        return nil, err
-    }
-    err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-    if err != nil {
-        return nil, err
-    }
-    return file, nil
+	err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = file.WriteString(strconv.Itoa(os.Getpid()))
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func GetLockFilePid(filename string) (pid int, err error) {
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return
+	}
+
+	pid, err = strconv.Atoi(string(contents))
+	return
 }

--- a/lock_posix.go
+++ b/lock_posix.go
@@ -35,6 +35,7 @@ func CreateLockFile(filename string) (*os.File, error) {
 		return nil, err
 	}
 
+	// Write PID to lock file
 	_, err = file.WriteString(strconv.Itoa(os.Getpid()))
 	if err != nil {
 		return nil, err
@@ -43,6 +44,7 @@ func CreateLockFile(filename string) (*os.File, error) {
 	return file, nil
 }
 
+// If filename is a lock file, returns the PID of the process locking it
 func GetLockFilePid(filename string) (pid int, err error) {
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/lock_windows.go
+++ b/lock_windows.go
@@ -3,24 +3,22 @@
 package singleinstance
 
 import (
-    "os"
+	"os"
 )
 
 // CreateLockFile try to create a file with given name
 // and acquire an exclusive lock on it
 // if the file already exists AND is still locked, it will fail
 func CreateLockFile(filename string) (*os.File, error) {
-    // if the files exists
-    if _, err := os.Stat(filename); err == nil {
-        // we first try to remove it
-        err = os.Remove(filename)
-        if err != nil {
-            return nil, err
-        }
+	// if the files exists
+	if _, err := os.Stat(filename); err == nil {
+		// we first try to remove it
+		err = os.Remove(filename)
+		if err != nil {
+			return nil, err
+		}
 
-    }
-    // and we try to acquire an exclusive "lock on it"
-    return os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0666)
+	}
+	// and we try to acquire an exclusive "lock on it"
+	return os.OpenFile(filename, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0666)
 }
-
-


### PR DESCRIPTION
Note: I ran [`gofmt`](https://golang.org/cmd/gofmt/) on all files so file formatting has been updated.

Another solution could be to `lsof`, but this iterates through all running processes so it's less efficient.

Fixes partially #2 
