### PR TITLE
Enable Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go-singleinstance
+
+go 1.15


### PR DESCRIPTION
GOPROXY only works for repos with Go modules enabled. This takes care of that.
It would also need to be tagged (for example: git tag v1.0.0) so that the module is versioned. 
It would be nice if you could merge it, otherwise I'll just use my fork.