### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module go-singleinstance
+module github.com/allan-simon/go-singleinstance
 
 go 1.15


### PR DESCRIPTION
The go.mod file has module go-singleinstance which is causing issue importing the package.
module declares its path as: go-singleinstance
                but was required as: github.com/allan-simon/go-singleinstance

This should be declared as
module github.com/allan-simon/go-singleinstance